### PR TITLE
import ID: ":" could appear in TXT

### DIFF
--- a/internal/provider/record.go
+++ b/internal/provider/record.go
@@ -21,6 +21,9 @@ import (
 	"github.com/veksh/terraform-provider-godaddy-dns/internal/model"
 )
 
+// import separator
+const IMPORT_SEP = ":"
+
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
 	_ resource.Resource                = &RecordResource{}
@@ -368,7 +371,7 @@ func (r *RecordResource) ImportState(ctx context.Context, req resource.ImportSta
 	// either as a separate structure in ReadRequest or as defaults: if only
 	// they were accessible, it would eliminate the need to pass anything here
 
-	idParts := strings.Split(req.ID, ":")
+	idParts := strings.SplitN(req.ID, IMPORT_SEP, 4)
 
 	// mb check format and emptiness
 	if len(idParts) != 4 {

--- a/internal/provider/record_test.go
+++ b/internal/provider/record_test.go
@@ -314,7 +314,7 @@ func TestAccTXTLifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						tfResName,
 						"data",
-						"updated text"),
+						string(mDataChanged)),
 				),
 			},
 		},

--- a/internal/provider/record_test.go
+++ b/internal/provider/record_test.go
@@ -269,7 +269,7 @@ func TestUnitNSNoopModIfOk(t *testing.T) {
 // with the same name (by pre-creating one and checking it is ok afterwards)
 func TestAccTXTLifecycle(t *testing.T) {
 	mData := model.DNSRecordData("test text")
-	mDataChanged := model.DNSRecordData("updated text")
+	mDataChanged := model.DNSRecordData("updated text" + IMPORT_SEP + " separator")
 	mDataOther := model.DNSRecordData("not to be modified")
 	mType, mName, preExisting, tfResName := makeMockRec(model.REC_TXT, mDataOther)
 	resource.Test(t, resource.TestCase{
@@ -326,7 +326,7 @@ func TestAccTXTLifecycle(t *testing.T) {
 // appeared after first application)
 func TestUnitTXTWithAnother(t *testing.T) {
 	mData := model.DNSRecordData("test text")
-	mDataChanged := model.DNSRecordData("changed text")
+	mDataChanged := model.DNSRecordData("changed text" + IMPORT_SEP + " here")
 	mDataOther := model.DNSRecordData("do not modify")
 	mDataYetAnother := model.DNSRecordData("also appears")
 	mType, mName, mRecs, tfResName := makeMockRec(model.REC_TXT, mData)


### PR DESCRIPTION
closes #8 and #9 by allowing ":" in TXT field on import