### PR TITLE
Rework rate limiting implementation to comply with GoDaddy API rate limits

### DIFF
--- a/libs/ratelimiter/ratelimiter.go
+++ b/libs/ratelimiter/ratelimiter.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+const (
+	// number of seconds required to refresh all tokens
+	TOKEN_REFRESH_TIME = 60
+	TOKEN_REFRESH_AS_SECONDS = time.Second * TOKEN_REFRESH_TIME
+)
+
 // simple token bucket rate limiter
 // - keeps track of available tokens and the last time a token was added
 // - on acquire: if there are tokens available, spend one and return immediately
@@ -16,14 +22,12 @@ import (
 //   - if none, wait until next one will be available (while holding mutex)
 type RateLimiter struct {
 	mu sync.Mutex
-	// interval between tokens, s
-	period time.Duration
 	// total bucket size; 1 means "no bursts"
 	bucketSize int
 	// current number of tokens in bucket
 	numTokens int
-	// the time last token was added
-	lastTokenTime time.Time
+	// the time the first token was used in this bucket
+	firstTokenUsedTime time.Time
 }
 
 // context to cancel, rate per second, burst (bucket) size
@@ -32,10 +36,9 @@ func New(rate, burst int) (*RateLimiter, error) {
 		return nil, errors.New("limiter rate and burst must be positive")
 	}
 	return &RateLimiter{
-		period:        time.Second / time.Duration(rate),
 		bucketSize:    burst,
 		numTokens:     burst,
-		lastTokenTime: time.Now(),
+		firstTokenUsedTime: time.Now(),
 	}, nil
 }
 
@@ -43,27 +46,34 @@ func New(rate, burst int) (*RateLimiter, error) {
 func (s *RateLimiter) Wait() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// if bucket is empty: add tokens that are due, update last refill time
+
+	// if bucket is empty: wait for TOKEN_REFRESH_TIME seconds since the first token was used, refill the bucket to (bucketSize),
+	// and set the first token time to time.Now() to set the new start of the period.
+	// this will help us comply with the GoDaddy APIs, which limit us to 60 requests every minute per endpoint.
+	// See: https://developer.godaddy.com/getstarted#terms
 	if s.numTokens <= 0 {
-		elapsedTime := time.Since(s.lastTokenTime)
-		tokensToAdd := int(elapsedTime.Nanoseconds() / s.period.Nanoseconds())
-		s.numTokens = tokensToAdd
-		if s.numTokens > s.bucketSize {
-			s.numTokens = s.bucketSize
+
+		// if less than TOKEN_REFRESH_TIME seconds has passed since firstTokenUsedTime,
+		// calculate firstTokenUsedTime + TOKEN_REFRESH_TIME and sleep until that time
+		if (time.Since(s.firstTokenUsedTime) <= TOKEN_REFRESH_AS_SECONDS) {
+			minimumRefreshTime := s.firstTokenUsedTime.Add(TOKEN_REFRESH_AS_SECONDS)
+			requiredTokenRefreshDuration := time.Since(minimumRefreshTime).Abs()
+
+			if (requiredTokenRefreshDuration > TOKEN_REFRESH_AS_SECONDS) {
+				// ensure we only sleep for TOKEN_REFRESH_AS_SECONDS seconds maximum
+				requiredTokenRefreshDuration = TOKEN_REFRESH_AS_SECONDS
+			}
+			time.Sleep(requiredTokenRefreshDuration)
 		}
-		s.lastTokenTime = s.lastTokenTime.Add(time.Duration(tokensToAdd) * s.period)
-	}
-	// if token available: ok, take it and release caller from the wait
-	if s.numTokens > 0 {
+
+		// now reset tokens and set first token use time
+		s.numTokens = s.bucketSize
+		s.firstTokenUsedTime = time.Now()
+	} else {
+		// if token available: ok, take it and release caller from the wait
 		s.numTokens--
 		return
 	}
-	// if still no tokens: will have to wait until nextTokenTime or cancel
-	nextTokenTime := s.lastTokenTime.Add(s.period)
-	waitDuration := time.Until(nextTokenTime)
-	time.Sleep(waitDuration)
-	// upd last token time and release from the wait
-	s.lastTokenTime = nextTokenTime
 }
 
 // block until token becomes available, with cancellable context
@@ -73,30 +83,45 @@ func (s *RateLimiter) WaitCtx(ctx context.Context) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// if bucket is empty: add tokens that are due, update last refill time
+	// if bucket is empty: wait for TOKEN_REFRESH_AS_SECONDS seconds since the last token was used, refill the bucket to (bucketSize),
+	// and set the last token time to time.Now() to set the new start of the period.
+	// this is unique to the GoDaddy APIs, which limit us to 60 requests every minute per endpoint.
+	// See: https://developer.godaddy.com/getstarted#terms
 	if s.numTokens <= 0 {
-		elapsedTime := time.Since(s.lastTokenTime)
-		tokensToAdd := int(elapsedTime.Nanoseconds() / s.period.Nanoseconds())
-		s.numTokens = tokensToAdd
-		if s.numTokens > s.bucketSize {
-			s.numTokens = s.bucketSize
+		// if less than TOKEN_REFRESH_AS_SECONDS seconds has passed since firstTokenUsedTime,
+		// calculate firstTokenUsedTime + TOKEN_REFRESH_AS_SECONDS and sleep until that time
+		requiredTokenRefreshDuration := time.Second * 0
+		if (time.Since(s.firstTokenUsedTime) <= TOKEN_REFRESH_AS_SECONDS) {
+			minimumRefreshTime := s.firstTokenUsedTime.Add(TOKEN_REFRESH_AS_SECONDS)
+			requiredTokenRefreshDuration = time.Since(minimumRefreshTime).Abs()
+
+			if (requiredTokenRefreshDuration > TOKEN_REFRESH_AS_SECONDS) {
+				// ensure we only sleep for TOKEN_REFRESH_AS_SECONDS seconds maximum
+				requiredTokenRefreshDuration = TOKEN_REFRESH_AS_SECONDS
+			}
+
+			if (requiredTokenRefreshDuration < 0) {
+				// don't wait for a negative amount of time. This is necessary since time.After() doesn't instantly
+				// return on a negative duration.
+				requiredTokenRefreshDuration = time.Second * 0
+			}
 		}
-		s.lastTokenTime = s.lastTokenTime.Add(time.Duration(tokensToAdd) * s.period)
+
+		s.numTokens = s.bucketSize
+
+		select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(requiredTokenRefreshDuration):
+		}
+		// if not cancelled: upd last token time and release from the wait
+		s.firstTokenUsedTime = time.Now()
+		return nil
 	}
 	// if token available: ok, take it and release caller from the wait
 	if s.numTokens > 0 {
 		s.numTokens--
 		return nil
 	}
-	// if still no tokens: will have to wait until nextTokenTime or cancel
-	nextTokenTime := s.lastTokenTime.Add(s.period)
-	waitDuration := time.Until(nextTokenTime)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(waitDuration):
-	}
-	// if not cancelled: upd last token time and release from the wait
-	s.lastTokenTime = nextTokenTime
 	return nil
 }


### PR DESCRIPTION
Hey @veksh, thanks again for creating this provider. After using it for some time, I realized that GoDaddy's rate limits work a bit differently than how they're modeled in the provider, which is causing larger Terraform plans to fail. Feel free to tweak or rework this PR as needed. Thanks!

[GoDaddy's current rate limits are:](https://developer.godaddy.com/getstarted#terms)
> Each API endpoint has an allotted number of calls you are allowed to make within a period of time (60 requests per minute). If you attempt to make more API calls to an endpoint than this allotted amount, the call will be rejected by the GoDaddy API and will return an HTTP status code of 429 and an error message indicating that your rate limit has been surpassed.

Steps to reproduce rate limit errors:
1. Run `terraform import` statements for at least 61 items
2. Try to execute a Terraform plan with at least one modification
3. Receive at least one `Error: Client Error` due to rate limit issues with the GoDaddy APIs

<img width="941" alt="Screenshot 2024-02-16 at 12 26 28 PM" src="https://github.com/veksh/terraform-provider-godaddy-dns/assets/1137427/4c4d001b-f9f9-44f1-98e7-90692c81913f">

This PR retools the rate limiter implementation to record the first token use time on initialization and then sleeps and resets this time so that only sixty requests can be used per sixty second time period.