### PR TITLE
allow DNS records to have a maximum TTL of 604800s (1 week)

### DIFF
--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -164,7 +164,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 ### Optional
 
 - `priority` (Number) Record priority, required for MX (lower is higher)
-- `ttl` (Number) Record time-to-live, >= 600s < 86400s, default 3600 seconds (1 hour)
+- `ttl` (Number) Record time-to-live, >= 600s < 604800s (1 week), default 3600 seconds (1 hour)
 
 ## Import
 

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -164,7 +164,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 ### Optional
 
 - `priority` (Number) Record priority, required for MX (lower is higher)
-- `ttl` (Number) Record time-to-live, >= 600s < 604800s (1 week), default 3600 seconds (1 hour)
+- `ttl` (Number) Record time-to-live, >= 600s <= 604800s (1 week), default 3600 seconds (1 hour)
 
 ## Import
 

--- a/internal/provider/record.go
+++ b/internal/provider/record.go
@@ -124,7 +124,7 @@ func (r *RecordResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Required:            true,
 			},
 			"ttl": schema.Int64Attribute{
-				MarkdownDescription: "Record time-to-live, >= 600s < 604800s (1 week), default 3600 seconds (1 hour)",
+				MarkdownDescription: "Record time-to-live, >= 600s <= 604800s (1 week), default 3600 seconds (1 hour)",
 				Optional:            true,
 				Computed:            true, // must be computed to use a default
 				Default:             int64default.StaticInt64(3600),

--- a/internal/provider/record.go
+++ b/internal/provider/record.go
@@ -124,13 +124,13 @@ func (r *RecordResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Required:            true,
 			},
 			"ttl": schema.Int64Attribute{
-				MarkdownDescription: "Record time-to-live, >= 600s < 86400s, default 3600 seconds (1 hour)",
+				MarkdownDescription: "Record time-to-live, >= 600s < 604800s (1 week), default 3600 seconds (1 hour)",
 				Optional:            true,
 				Computed:            true, // must be computed to use a default
 				Default:             int64default.StaticInt64(3600),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(600),
-					int64validator.AtMost(86400),
+					int64validator.AtMost(604800),
 				},
 			},
 			"priority": schema.Int64Attribute{


### PR DESCRIPTION
Hey @veksh, I'm back with another small PR as I continue making use of this provider. This PR allows DNS records to have a maximum TTL of 604800s (1 week), which matches up with the GoDaddy DNS editor UI.

DNS TTL records can be allowed maximum values that extend into years. As an example, the following record update call is considered valid by the GoDaddy API:

```
curl --location --request PATCH 'https://api.godaddy.com/v1/domains/yourdomain.com/records' \
--header 'Authorization: sso-key key:secret' \
--header 'Content-Type: application/json' \
--data '[
    {
        "data": "127.0.0.1",
        "name": "abc",
        "ttl": 604800,
        "type": "A"
    }
]'
```

However, trying to use a maximum TTL length higher than `86400` with this provider currently fails:
<img width="1105" alt="Screenshot 2024-02-20 at 6 39 37 PM" src="https://github.com/veksh/terraform-provider-godaddy-dns/assets/1137427/27d2f4e0-3d1a-44ba-8e08-36c4c4293617">

I'd like to up the maximum allowable length to the value `604800`, which matches the highest option selectable in the GoDaddy DNS UI:

<img width="1358" alt="Screenshot 2024-02-20 at 6 40 38 PM" src="https://github.com/veksh/terraform-provider-godaddy-dns/assets/1137427/cbe94142-9359-4485-af32-a171b43d9586">


